### PR TITLE
fix simple-sha1 on insecure origins

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -18,13 +18,21 @@ function sha1 (buf, cb) {
     buf = uint8array(buf)
   }
 
-  subtle.digest({ name: 'sha-1' }, buf)
-    .then(function (result) {
-      cb(hex(new Uint8Array(result)))
-    }, function () {
-      // Promise will be rejected on non-secure origins. See: http://goo.gl/lq4gCo
-      cb(sha1sync(buf))
-    })
+  var promise
+  try {
+    promise = subtle.digest({ name: 'sha-1' }, buf)
+  } catch (err) {
+    // Exception thrown when browser lacks digest support for sha-1
+    setTimeout(cb, 0, sha1sync(buf))
+    return
+  }
+
+  promise.then(function (result) {
+    cb(hex(new Uint8Array(result)))
+  }, function () {
+    // Promise will be rejected on non-secure origins. See: http://goo.gl/lq4gCo
+    cb(sha1sync(buf))
+  })
 }
 
 function sha1sync (buf) {

--- a/browser.js
+++ b/browser.js
@@ -5,7 +5,7 @@ var crypto = window.crypto || window.msCrypto || {}
 var subtle = crypto.subtle || crypto.webkitSubtle
 
 // Rusha inserts a global for some reason
-delete window.Rusha 
+delete window.Rusha
 
 function sha1 (buf, cb) {
   if (!subtle) {

--- a/browser.js
+++ b/browser.js
@@ -21,6 +21,9 @@ function sha1 (buf, cb) {
   subtle.digest({ name: 'sha-1' }, buf)
     .then(function (result) {
       cb(hex(new Uint8Array(result)))
+    }, function () {
+      // Promise will be rejected on non-secure origins. See: http://goo.gl/lq4gCo
+      cb(sha1sync(buf))
     })
 }
 


### PR DESCRIPTION
Chrome has web crypto support, but disables it for non-secure origins
(totally brain dead). Handle this case by falling back to Rusha
