### PR TITLE
Handle promise error on http sites; http perf improvement

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6,8 +6,12 @@ var subtle = crypto.subtle || crypto.webkitSubtle
 var sha1sync = rusha.digest.bind(rusha)
 
 // Browsers throw if they lack support for an algorithm.
-try { subtle.digest({ name: 'sha-1'}, new Uint8Array) }
-catch (err) { subtle = false }
+// Promise will be rejected on non-secure origins. (http://goo.gl/lq4gCo)
+try {
+  subtle.digest({ name: 'sha-1' }, new Uint8Array).catch(function () {
+    subtle = false
+  })
+} catch (err) { subtle = false }
 
 // Rusha inserts a global for some reason.
 delete window.Rusha
@@ -27,8 +31,6 @@ function sha1 (buf, cb) {
     .then(function succeed (result) {
       cb(hex(new Uint8Array(result)))
     },
-    // Promise will be rejected on non-secure origins.
-    // See: http://goo.gl/lq4gCo
     function fail (error) {
       cb(sha1sync(buf))
     })


### PR DESCRIPTION
In Chrome 42, an error is logged when a promise has an error that is
not handled. So, even though this block has a try-catch around it, we
need to handle the case where the site is “non-secure” (http) and
supports crypto.subtle, in which case this first promise will be
rejected.

This is the error:

```
Uncaught (in promise)
DOMException: Only secure origins are allowed. http://goo.gl/lq4gCo
```

While we’re at it, let’s set `subtle = false` so that after the first
failed promise we don’t need to pay the cost of failed promises for
each call to sha1()
