### PR TITLE
Supporting web workers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,8 @@
 var Rusha = require('rusha')
 
 var rusha = new Rusha
-var crypto = window.crypto || window.msCrypto || {}
+var scope = typeof window !== 'undefined' ? window : self
+var crypto = scope.crypto || scope.msCrypto || {}
 var subtle = crypto.subtle || crypto.webkitSubtle
 
 function sha1sync (buf) {


### PR DESCRIPTION
Web workers do not have `window` defined, but they do have `self`
defined which returns the workers global scope. If the web worker
supports the crypto api, it'll be found under `self`

Awesome project btw! 👍 