### PR TITLE
Add react-native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple api for generating sha1 hashes in node and the browser.",
   "main": "index.js",
   "browser": "browser.js",
+  "react-native": "index.js",
   "scripts": {
     "test": "npm run test-node && npm run test-browser",
     "test-local": "npm run test-node && npm run test-browser-local",


### PR DESCRIPTION
I'm using this as a dependency of `discovery-swarm` which I'm trying to set up in react-native.

I'm using [rn-nodeify](https://github.com/tradle/rn-nodeify) which kind of acts like Browserify in that it adds support for various node APIs to RN. One of the libraries it adds support for is the `crypto` module. It doesn't support webcrypto, however.

When RN tries to load this module, it detects the `browser` field and tries to load the browser implementation which fails. Adding the `react-native` field to the package.json forces it to use the node implementation which in turn uses the rn-nodeify implementation of `crypto`.