### PR TITLE
Add standard JS; add sync fallback on error

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -3,7 +3,7 @@ var gitsha1 = require('git-sha1')
 var sha1 = require('./')
 
 var size = Math.pow(2, 24)
-var buffer = new Buffer(size)
+var buffer = Buffer.alloc(size)
 
 benchmark.Suite()
   .add('sha1', function () {
@@ -32,8 +32,7 @@ function complete () {
   if (process.browser) {
     var crypto = window.crypto || window.msCrypto || {}
     var subtle = crypto.subtle || crypto.webkitSubtle
-    try { subtle.digest({ name: 'sha-1'}, new Uint8Array) }
-    catch (err) { subtle = false }
+    try { subtle.digest({ name: 'sha-1' }, new Uint8Array()) } catch (err) { subtle = false }
     if (subtle) console.log('sha1 used WebCryptoAPI')
   }
   console.log('Fastest is ' + this.filter('fastest').map('name'))

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "browser.js",
   "react-native": "index.js",
   "scripts": {
-    "test": "npm run test-node && npm run test-browser",
+    "test": "standard && npm run test-node && npm run test-browser",
     "test-local": "npm run test-node && npm run test-browser-local",
     "test-node": "tape test/*.js",
     "test-browser": "airtap -- test/*.js",
@@ -39,6 +39,7 @@
     "beefy": "^2.1.1",
     "benchmark": "^2.1.0",
     "git-sha1": "^0.1.2",
+    "standard": "^14.1.0",
     "tape": "^4.5.1"
   }
 }

--- a/rusha-worker-sha1.js
+++ b/rusha-worker-sha1.js
@@ -10,10 +10,9 @@ worker.onmessage = function onRushaMessage (e) {
   delete cbs[taskId]
 
   if (e.data.error != null) {
-    // This should never happen!
-    throw new Error('Rusha worker error: ' + e.data.error)
+    cb(new Error('Rusha worker error: ' + e.data.error))
   } else {
-    cb(e.data.hash)
+    cb(null, e.data.hash)
   }
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,7 +4,7 @@ var test = require('tape')
 test('sha1', function (t) {
   t.plan(2)
   // buffer
-  sha1(new Buffer('hey there'), function (hash) {
+  sha1(Buffer.from('hey there'), function (hash) {
     t.equal(hash, '6b1c01703b68cf9b35ab049385900b5c428651b6')
   })
   // string
@@ -15,7 +15,7 @@ test('sha1', function (t) {
 
 test('sha1.sync', function (t) {
   // buffer
-  t.equal(sha1.sync(new Buffer('hey there')), '6b1c01703b68cf9b35ab049385900b5c428651b6')
+  t.equal(sha1.sync(Buffer.from('hey there')), '6b1c01703b68cf9b35ab049385900b5c428651b6')
   // string
   t.equal(sha1.sync('hey there'), '6b1c01703b68cf9b35ab049385900b5c428651b6')
   t.end()


### PR DESCRIPTION
The code style is already basically StandardJS. Let's add a linter to catch errors.

I also better handle the case where an error occurs with the Rusha SHA1 worker. On error, we fallback to synchronous method which cannot fail.